### PR TITLE
Add insert-timestamp dedupe

### DIFF
--- a/lib/streamaggr/dedup_test.go
+++ b/lib/streamaggr/dedup_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDedupAggrSerial(t *testing.T) {
-	da := newDedupAggr()
+	da := newDedupAggr(false)
 
 	const seriesCount = 100_000
 	expectedSamplesMap := make(map[string]pushSample)
@@ -57,7 +57,7 @@ func TestDedupAggrSerial(t *testing.T) {
 func TestDedupAggrConcurrent(_ *testing.T) {
 	const concurrency = 5
 	const seriesCount = 10_000
-	da := newDedupAggr()
+	da := newDedupAggr(false)
 
 	var wg sync.WaitGroup
 	for i := 0; i < concurrency; i++ {

--- a/lib/streamaggr/dedup_timing_test.go
+++ b/lib/streamaggr/dedup_timing_test.go
@@ -19,7 +19,7 @@ func BenchmarkDedupAggr(b *testing.B) {
 func benchmarkDedupAggr(b *testing.B, samplesPerPush int) {
 	const loops = 2
 	benchSamples := newBenchSamples(samplesPerPush)
-	da := newDedupAggr()
+	da := newDedupAggr(false)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/lib/streamaggr/deduplicator_test.go
+++ b/lib/streamaggr/deduplicator_test.go
@@ -32,7 +32,7 @@ baz_aaa_aaa_fdd{instance="x",job="aaa",pod="sdfd-dfdfdfs",node="aosijjewrerfd",n
 `, offsetMsecs)
 
 	dedupInterval := time.Hour
-	d := NewDeduplicator(pushFunc, true, dedupInterval, []string{"node", "instance"}, "global")
+	d := NewDeduplicator(pushFunc, true, dedupInterval, []string{"node", "instance"}, "global", false)
 	for i := 0; i < 10; i++ {
 		d.Push(tss)
 	}

--- a/lib/streamaggr/deduplicator_timing_test.go
+++ b/lib/streamaggr/deduplicator_timing_test.go
@@ -9,7 +9,7 @@ import (
 
 func BenchmarkDeduplicatorPush(b *testing.B) {
 	pushFunc := func(_ []prompbmarshal.TimeSeries) {}
-	d := NewDeduplicator(pushFunc, true, time.Hour, nil, "global")
+	d := NewDeduplicator(pushFunc, true, time.Hour, nil, "global", false)
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(benchSeries)))


### PR DESCRIPTION
## Summary
- add `DedupUseInsertTimestamp` flag to stream aggregation options
- include insert timestamp in `pushSample` and deduplication state
- prefer highest insert timestamp during deduplication
- plumb new flag through vminsert and vmagent CLI options

## Testing
- `go test ./lib/streamaggr/...` *(failed: no route to host during toolchain download)*